### PR TITLE
Enable stack-name deploy option to override auto generated stack name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Options:_
 `-t, --template`: Path to a SAM template. Defaults to `sam.(json|yaml)` in the current directory.  
 `-e, --environment`: An environment name to deploy. Defaults to "development".  
 `-p, --parameters`: A list of parameters to override in your template.
+`-s, --stack-name`: Option to override the auto-generated environment stack name.
 
 sammie will automatically create an s3 bucket to upload your code. To change this to a different bucket, change `bucketName` in your `sam.json` template.
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -28,8 +28,9 @@ async function getStackOutputs(stackName) {
 module.exports = async function deploy(input) {
   await validate(input)
   const { templatePathEnvMerged, templatePathPackaged, environment, parameters } = await packageProject(input)
-  const stackName = `${parameters.stackName.Default}-${environment}`
-  const deployParams = [].concat(input.parameters || [], `environment=${environment}`)
+  const inputParams = input.parameters || []
+  const stackName = inputParams.stackName || `${parameters.stackName.Default}-${environment}`
+  const deployParams = [].concat(inputParams, `environment=${environment}`)
   await deployStack(templatePathPackaged, stackName, input.capabilities, deployParams)
   log.success('Deployed')
   deleteFileAsync(templatePathPackaged)

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -28,9 +28,8 @@ async function getStackOutputs(stackName) {
 module.exports = async function deploy(input) {
   await validate(input)
   const { templatePathEnvMerged, templatePathPackaged, environment, parameters } = await packageProject(input)
-  const inputParams = input.parameters || []
-  const stackName = inputParams.stackName || `${parameters.stackName.Default}-${environment}`
-  const deployParams = [].concat(inputParams, `environment=${environment}`)
+  const stackName = input['stack-name'] || `${parameters.stackName.Default}-${environment}`
+  const deployParams = [].concat(input.parameters || [], `environment=${environment}`)
   await deployStack(templatePathPackaged, stackName, input.capabilities, deployParams)
   log.success('Deployed')
   deleteFileAsync(templatePathPackaged)

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ cli
   .option('-t, --template', 'Path to a SAM template. Defaults to `sam.(json|yaml)` in the current directory.')
   .option('-e, --environment', 'An environment name to deploy. Defaults to "development".')
   .option('-p, --parameters', 'A list of parameters to override in your template.')
+  .option('-s, --stack-name', 'Option to override the auto-generated environment stack name.')
   .example('deploy')
   .example('deploy --template ./configs/sam.json --environment production --parameters key1=val1 key2=val2')
   .action(deploy)


### PR DESCRIPTION
Currently, the deployed stack name is auto-generated based on Parameters.stackName + environment. e.g.:
```json
"Parameters": {
    "stackName": { "Type": "String",  "Default": "foo" }
}
```
Would generate `foo-development` on `sammie deploy`

This PR allows you to completely override it:
`sammie deploy --stack-name awesome-stack`

This also matches aws cli's underlying stack-name option.