### PR TITLE
Deploy: stack outputs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _Options:_
 `-s, --stack-name`: Option to override the auto-generated environment stack name.  
 `--s3-bucket`: S3 bucket where code is uploaded. Defaults to Parameters.bucketName in template which is generated for you.  
 `--s3-prefix`: S3 path prefix added to the packaged code file. Defaults to stackName/year.
+`-o, --outputs`: Prints the stack's outputs to the console.
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ cli
   .option('--s3-bucket', 'S3 bucket where code is uploaded. Defaults to Parameters.bucketName in template')
   .option('--s3-prefix', 'S3 path prefix added to the packaged code file. Defaults to stackName/year')
   .option('--capabilities', 'See `aws cloudformation deploy`. Defaults to CAPABILITY_IAM')
+  .option('-o, --outputs', `Prints the stack's outputs to the console`)
   .example('deploy')
   .example('deploy --template ./configs/sam.json --environment production -p key1=val1 -p key2=val2')
   .action(deploy)

--- a/src/log.js
+++ b/src/log.js
@@ -1,26 +1,33 @@
+/* eslint-disable no-console */
+
 const { cyan, green, yellow, red } = require('chalk')
 const prefix = '[sammie]'
 
 function info(...args) {
-  console.info(cyan(prefix), ...args) // eslint-disable-line no-console
+  console.info(cyan(prefix), ...args)
   return log
 }
 
 function error(...args) {
-  console.error(red(args)) // eslint-disable-line no-console
+  console.error(red(args))
   return log
 }
 
 function command(...args) {
-  console.log(yellow(args)) // eslint-disable-line no-console
+  console.log(yellow(args))
   return log
 }
 
 function success(...args) {
-  console.info(green(prefix), ...args, green('✔︎')) // eslint-disable-line no-console
+  console.info(green(prefix), ...args, green('✔︎'))
   return log
 }
 
-const log = { info, success, error, command }
+function raw(...args) {
+  console.log(...args)
+  return log
+}
+
+const log = { info, error, command, success, raw }
 
 module.exports = log


### PR DESCRIPTION
Option to print the stack "Outputs" as text to the console after deploying.  Useful if you want to use them in a shell script.